### PR TITLE
update lang on client side navigation

### DIFF
--- a/vike-vue/renderer/+config.ts
+++ b/vike-vue/renderer/+config.ts
@@ -36,7 +36,7 @@ export default {
   // be used by the renderers.
   // It is a cumulative config option, so a web app using vike-vue can extend
   // this list.
-  passToClient: ['pageProps', 'title'],
+  passToClient: ['pageProps', 'title', 'lang'],
 
   clientRouting: true,
   hydrationCanBeAborted: true,
@@ -57,7 +57,7 @@ export default {
       env: { server: true }
     },
     lang: {
-      env: { server: true }
+      env: { server: true, client: true }
     },
     ssr: {
       env: { config: true },

--- a/vike-vue/renderer/getLang.ts
+++ b/vike-vue/renderer/getLang.ts
@@ -1,0 +1,36 @@
+export { getLang }
+
+import type { PageContext } from 'vike/types'
+import { isCallable } from './utils/isCallable.js'
+
+/**
+ * Get the page's lang if defined, either from the config, the additional data fetched by
+ * the page's data() and onBeforeRender() hooks or from other hooks.
+ */
+function getLang(pageContext: PageContext): null | string {
+  // from onBeforeRoute() hook & other hooks, e.g. onPrerenderStart() hook
+  if (pageContext.lang !== undefined) {
+    return pageContext.lang
+  }
+
+  const langConfig = pageContext.configEntries.lang?.[0]
+  if (!langConfig) {
+    return null
+  }
+  const lang = langConfig.configValue
+  if (typeof lang === 'string') {
+    return lang
+  }
+  if (!lang) {
+    return null
+  }
+  const { configDefinedAt } = langConfig
+  if (isCallable(lang)) {
+    const val = lang(pageContext)
+    if (typeof val !== 'string') {
+      throw new Error(configDefinedAt + ' should return a string')
+    }
+    return val
+  }
+  throw new Error(configDefinedAt + ' should be a string or a function returning a string')
+}

--- a/vike-vue/renderer/onRenderClient.ts
+++ b/vike-vue/renderer/onRenderClient.ts
@@ -2,6 +2,7 @@
 export { onRenderClient }
 
 import { createVueApp } from './app.js'
+import { getLang } from './getLang.js'
 import { getTitle } from './getTitle.js'
 import type { OnRenderClientAsync } from 'vike/types'
 
@@ -29,6 +30,8 @@ const onRenderClient: OnRenderClientAsync = async (pageContext): ReturnType<OnRe
     // previous page. It can even be null, in which case we should unset the
     // document title.
     const title = getTitle(pageContext)
+    const lang = getLang(pageContext) || 'en'
     document.title = title || ''
+    document.documentElement.lang = lang
   }
 }

--- a/vike-vue/renderer/onRenderHtml.ts
+++ b/vike-vue/renderer/onRenderHtml.ts
@@ -4,6 +4,7 @@ export { onRenderHtml }
 import { renderToNodeStream, renderToString } from 'vue/server-renderer'
 import { dangerouslySkipEscape, escapeInject, version } from 'vike/server'
 import { getTitle } from './getTitle.js'
+import { getLang } from './getLang.js'
 import type { OnRenderHtmlAsync } from 'vike/types'
 import { createVueApp } from './app.js'
 import { App } from 'vue'
@@ -42,7 +43,7 @@ const onRenderHtml: OnRenderHtmlAsync = async (pageContext): ReturnType<OnRender
     headHtml = dangerouslySkipEscape(await renderToStringWithErrorHandling(app))
   }
 
-  const lang = pageContext.config.lang || 'en'
+  const lang = getLang(pageContext) || 'en'
 
   const documentHtml = escapeInject`<!DOCTYPE html>
     <html lang='${lang}'>

--- a/vike-vue/renderer/types.ts
+++ b/vike-vue/renderer/types.ts
@@ -23,6 +23,8 @@ declare global {
       /** &lt;title>${title}&lt;/title> - set by onBeforeRender() hook, has precedence over the config */
       title?: string
 
+      lang?: string
+
       // Needed by getTitle()
       data?: {
         /** &lt;title>${title}&lt;/title> - set by data() hook, has precedence over the onBeforeRender() hook */


### PR DESCRIPTION
closes #55 

This is basically the same as https://github.com/vikejs/vike-react/pull/61

One thing I'd like to remark - how about having `getLang` not return null, but the default value `en` since that's what we'll be using as a fallback anyways? Right now, calling `getLang` from any component would return null, which imo is incorrect since we've set a lang attribute.