### PR TITLE
Add onCreateApp hook

### DIFF
--- a/examples/with-vue-plugin/pages/+onCreateApp.ts
+++ b/examples/with-vue-plugin/pages/+onCreateApp.ts
@@ -1,8 +1,10 @@
-import type { OnCreateAppSync } from "vike-vue"
+export { onCreateApp }
 
-// callback that is invoked right after creating the app - useful for registering plugins, etc.
-const onCreateApp: OnCreateAppSync = ({ app }): ReturnType<OnCreateAppSync> => {
+import type { OnCreateAppSync } from 'vike-vue'
+import ToastPlugin from 'vue-toast-notification'
+
+const onCreateApp: OnCreateAppSync = (pageContext): ReturnType<OnCreateAppSync> => {
+  const { app } = pageContext
+  app.use(ToastPlugin)
   console.log(`Vue version: ${app.version}`)
 }
-
-export default onCreateApp

--- a/examples/with-vue-plugin/pages/+onCreateApp.ts
+++ b/examples/with-vue-plugin/pages/+onCreateApp.ts
@@ -1,8 +1,8 @@
 import type { OnCreateAppSync } from "vike-vue"
 
 // callback that is invoked right after creating the app - useful for registering plugins, etc.
-const onCreateApp: OnCreateAppSync = (app, pageContext): ReturnType<OnCreateAppSync> => {
-  console.log('onCreateApp')
+const onCreateApp: OnCreateAppSync = ({ app }): ReturnType<OnCreateAppSync> => {
+  console.log(`Vue version: ${app.version}`)
 }
 
 export default onCreateApp

--- a/examples/with-vue-plugin/pages/+onCreateApp.ts
+++ b/examples/with-vue-plugin/pages/+onCreateApp.ts
@@ -1,0 +1,8 @@
+import type { OnCreateAppSync } from "vike-vue"
+
+// callback that is invoked right after creating the app - useful for registering plugins, etc.
+const onCreateApp: OnCreateAppSync = (app, pageContext): ReturnType<OnCreateAppSync> => {
+  console.log('onCreateApp')
+}
+
+export default onCreateApp

--- a/examples/with-vue-plugin/pages/+vuePlugins.ts
+++ b/examples/with-vue-plugin/pages/+vuePlugins.ts
@@ -1,9 +1,0 @@
-import ToastPlugin from 'vue-toast-notification'
-
-// List of Vue plugins to install.
-export default [
-  {
-    plugin: ToastPlugin
-    // , options: { foo: 'bar' }
-  }
-]

--- a/vike-vue/renderer/+config.ts
+++ b/vike-vue/renderer/+config.ts
@@ -1,6 +1,12 @@
+export type { OnCreateAppSync }
+export type { OnCreateAppAsync }
+
 import type { Config, ConfigEffect, PageContext } from 'vike/types'
 import type { Component } from './types'
-import { Plugin } from 'vue'
+import type { App, Plugin } from 'vue'
+
+type OnCreateAppSync = (app: App, pageContext: PageContext) => void
+type OnCreateAppAsync = (app: App, pageContext: PageContext) => Promise<void>
 
 // Depending on the value of `config.meta.ssr`, set other config options' `env`
 // accordingly.
@@ -72,6 +78,9 @@ export default {
       // the client always, but if SSR is disabled, onRenderHtml won't make use
       // of it.
       env: { server: true, client: true }
+    },
+    onCreateApp: {
+      env: { server: true, client: true }
     }
   }
 } satisfies Config
@@ -139,6 +148,11 @@ declare global {
 
       /** The page's root Vue component */
       Page?: Component
+
+      /**
+       * Hook that is invoked after the app has been created.
+       */
+      onCreateApp?: OnCreateAppSync | OnCreateAppAsync
     }
   }
 }

--- a/vike-vue/renderer/+config.ts
+++ b/vike-vue/renderer/+config.ts
@@ -142,7 +142,7 @@ declare global {
        * See https://vuejs.org/guide/reusability/plugins.html
        *
        * @default []
-       *
+       * @deprecated Use {@link onCreateApp} instead
        */
       vuePlugins?: VuePluginWithOptions[]
 

--- a/vike-vue/renderer/+config.ts
+++ b/vike-vue/renderer/+config.ts
@@ -5,8 +5,9 @@ import type { Config, ConfigEffect, PageContext } from 'vike/types'
 import type { Component } from './types'
 import type { App, Plugin } from 'vue'
 
-type OnCreateAppSync = (app: App, pageContext: PageContext) => void
-type OnCreateAppAsync = (app: App, pageContext: PageContext) => Promise<void>
+type PageContextWithApp = PageContext & { app: App }
+type OnCreateAppSync = (pageContext: PageContextWithApp) => void
+type OnCreateAppAsync = (pageContext: PageContextWithApp) => Promise<void>
 
 // Depending on the value of `config.meta.ssr`, set other config options' `env`
 // accordingly.

--- a/vike-vue/renderer/+config.ts
+++ b/vike-vue/renderer/+config.ts
@@ -5,9 +5,26 @@ import type { Config, ConfigEffect, PageContext } from 'vike/types'
 import type { Component } from './types'
 import type { App, Plugin } from 'vue'
 
-type PageContextWithApp = PageContext & { app: App }
-type OnCreateAppSync = (pageContext: PageContextWithApp) => void
-type OnCreateAppAsync = (pageContext: PageContextWithApp) => Promise<void>
+/**
+ * Hook called right after creating Vue's `app` instance.
+ *
+ * Typically used for registering Vue plugins.
+ *
+ * See also:
+ *  - https://vuejs.org/guide/reusability/plugins.html
+ *  - https://vuejs.org/api/application.html#createapp
+ */
+type OnCreateAppSync = (pageContext: PageContext & { app: App }) => void
+/**
+ * Hook called right after creating Vue's `app` instance.
+ *
+ * Typically used for registering Vue plugins.
+ *
+ * See also:
+ *  - https://vuejs.org/guide/reusability/plugins.html
+ *  - https://vuejs.org/api/application.html#createapp
+ */
+type OnCreateAppAsync = (pageContext: PageContext & { app: App }) => Promise<void>
 
 // Depending on the value of `config.meta.ssr`, set other config options' `env`
 // accordingly.
@@ -136,22 +153,20 @@ declare global {
        */
       stream?: boolean
 
-      /**
-       * List of Vue plugins (and their respective options) to be installed with
-       * `app.vue(plugin, options)`.
-       *
-       * See https://vuejs.org/guide/reusability/plugins.html
-       *
-       * @default []
-       * @deprecated Use {@link onCreateApp} instead
-       */
+      /** @deprecated Use `onCreateApp()` instead. */
       vuePlugins?: VuePluginWithOptions[]
 
       /** The page's root Vue component */
       Page?: Component
 
       /**
-       * Hook that is invoked after the app has been created.
+       * Hook called right after creating Vue's `app` instance.
+       *
+       * Typically used for registering Vue plugins.
+       *
+       * See also:
+       *  - https://vuejs.org/guide/reusability/plugins.html
+       *  - https://vuejs.org/api/application.html#createapp
        */
       onCreateApp?: OnCreateAppSync | OnCreateAppAsync
     }

--- a/vike-vue/renderer/app.ts
+++ b/vike-vue/renderer/app.ts
@@ -73,20 +73,18 @@ function createVueApp(pageContext: PageContext, ssrApp = true, renderHead = fals
   // We therefore use a reactive pageContext.
   const pageContextReactive = reactive(pageContext)
 
+  objectAssign(pageContext, { app })
+  pageContext.config.onCreateApp?.(pageContext)
+
   // Make `pageContext` accessible from any Vue component
   setPageContext(app, pageContextReactive)
 
   if (pageContext.config.vuePlugins) {
-    console.warn('[Warning] +vuePlugins.js is deprecated, use +onCreateApp() instead')
+    console.warn('[vike-vue][warning] +vuePlugins.js is deprecated, use onCreateApp() instead')
     pageContext.config.vuePlugins.forEach(({ plugin, options }) => {
       app.use(plugin, options)
     })
   }
-
-  // avoid copying here
-  const ctxWithApp = Object.assign(pageContext, { app })
-
-  pageContext.config.onCreateApp?.(ctxWithApp)
 
   return app
 }

--- a/vike-vue/renderer/app.ts
+++ b/vike-vue/renderer/app.ts
@@ -82,7 +82,11 @@ function createVueApp(pageContext: PageContext, ssrApp = true, renderHead = fals
       app.use(plugin, options)
     })
   }
-  pageContext.config.onCreateApp?.(app, pageContext)
+
+  // avoid copying here
+  const ctxWithApp = Object.assign(pageContext, { app })
+
+  pageContext.config.onCreateApp?.(ctxWithApp)
 
   return app
 }

--- a/vike-vue/renderer/app.ts
+++ b/vike-vue/renderer/app.ts
@@ -76,5 +76,7 @@ function createVueApp(pageContext: PageContext, ssrApp = true, renderHead = fals
   // Make `pageContext` accessible from any Vue component
   setPageContext(app, pageContextReactive)
 
+  pageContext.config.onCreateApp?.(app, pageContext)
+
   return app
 }

--- a/vike-vue/renderer/app.ts
+++ b/vike-vue/renderer/app.ts
@@ -76,6 +76,12 @@ function createVueApp(pageContext: PageContext, ssrApp = true, renderHead = fals
   // Make `pageContext` accessible from any Vue component
   setPageContext(app, pageContextReactive)
 
+  if (pageContext.config.vuePlugins) {
+    console.warn('[Warning] +vuePlugins.js is deprecated, use +onCreateApp() instead')
+    pageContext.config.vuePlugins.forEach(({ plugin, options }) => {
+      app.use(plugin, options)
+    })
+  }
   pageContext.config.onCreateApp?.(app, pageContext)
 
   return app

--- a/vike-vue/renderer/onRenderClient.ts
+++ b/vike-vue/renderer/onRenderClient.ts
@@ -14,11 +14,6 @@ const onRenderClient: OnRenderClientAsync = async (pageContext): ReturnType<OnRe
     const container = document.getElementById('page-view')!
     const ssr = container.innerHTML !== ''
     app = createVueApp(pageContext, ssr)
-    if (pageContext.config.vuePlugins) {
-      pageContext.config.vuePlugins.forEach(({ plugin, options }) => {
-        app.use(plugin, options)
-      })
-    }
     app.mount(container)
   } else {
     // Client routing

--- a/vike-vue/renderer/onRenderHtml.ts
+++ b/vike-vue/renderer/onRenderHtml.ts
@@ -18,11 +18,6 @@ const onRenderHtml: OnRenderHtmlAsync = async (pageContext): ReturnType<OnRender
   if (!!pageContext.Page) {
     // SSR is enabled
     const app = createVueApp(pageContext)
-    if (pageContext.config.vuePlugins) {
-      pageContext.config.vuePlugins.forEach(({ plugin, options }) => {
-        app.use(plugin, options)
-      })
-    }
     pageView = !stream
       ? dangerouslySkipEscape(await renderToStringWithErrorHandling(app))
       : renderToNodeStreamWithErrorHandling(app)


### PR DESCRIPTION
close #60 

This adds a hook `onCreateApp` that is invoked when the app is created, both on the server and the client.

Two more things:
1. Why do both `onRenderClient` and `onRenderHtml` use the `vuePlugins` hook? Couldn't that live inside `app.ts` just like the code in this PR?
2. This hook overlaps conceptually with the `vuePlugins` hook, which can still be used to have a shortcut to defining plugins. However, some people might use that hook while others might use `onCreateApp` and then do `app.use(plugin)` in there. Should we just leave it up to the user in this case and accept a little bit of fragmentation?