### PR TITLE
fix: rename root ID `#vue-root` => `#app`

### DIFF
--- a/examples/full/.test.ts
+++ b/examples/full/.test.ts
@@ -33,7 +33,7 @@ function runTest() {
     test(url + ' (HTML)', async () => {
       const html = await fetchHtml(url)
       // Isn't rendered to HTML
-      expect(html).toContain('<div id="vue-root"></div>')
+      expect(html).toContain('<div id="app"></div>')
       expect(html).not.toContain(text)
       expect(getTitle(html)).toBe(title)
     })

--- a/packages/vike-vue/src/renderer/onRenderClient.ts
+++ b/packages/vike-vue/src/renderer/onRenderClient.ts
@@ -11,7 +11,7 @@ const onRenderClient: OnRenderClientAsync = async (pageContext): ReturnType<OnRe
   if (!app) {
     // First rendering/hydration
 
-    const container = document.getElementById('vue-root')!
+    const container = document.getElementById('app')!
     const ssr = container.innerHTML !== ''
     const ctxWithApp = await createVueApp(pageContext, ssr, 'Page')
     app = ctxWithApp.app

--- a/packages/vike-vue/src/renderer/onRenderHtml.ts
+++ b/packages/vike-vue/src/renderer/onRenderHtml.ts
@@ -55,7 +55,7 @@ const onRenderHtml: OnRenderHtmlAsync = async (pageContext): ReturnType<OnRender
         ${faviconTag}
       </head>
       <body>
-        <div id="vue-root">${pageView}</div>
+        <div id="app">${pageView}</div>
       </body>
       <!-- built with https://github.com/vikejs/vike-vue -->
     </html>`


### PR DESCRIPTION
Following the widespread convention, so that migrating to Vike is slightly easier.

Do you mind if I release a minor for this? I need this for a migration document I'm writing. (Strictly speaking it's a breaking change, but IMHO I think we can release it as a minor. But let me know if you disagree.)