### PR TITLE
fix: cleanup old keys and use shallowReactive instead of reactive for dataReactive and pageContextReactive  #116, #121

### DIFF
--- a/examples/full/pages/star-wars/index/+Page.vue
+++ b/examples/full/pages/star-wars/index/+Page.vue
@@ -12,5 +12,5 @@
 <script lang="ts" setup>
 import type { Data } from './+data'
 import { useData } from 'vike-vue/useData'
-const movies = useData<Data>()
+const { movies } = useData<Data>()
 </script>

--- a/examples/full/pages/star-wars/index/+data.ts
+++ b/examples/full/pages/star-wars/index/+data.ts
@@ -11,7 +11,7 @@ const data = async () => {
   // We remove data we don't need because the data is passed to the client; we should
   // minimize what is sent over the network.
   const movies = minimize(moviesData)
-  return movies
+  return { movies }
 }
 
 function minimize(movies: MovieDetails[]): Movie[] {

--- a/examples/full/pages/star-wars/index/+title.ts
+++ b/examples/full/pages/star-wars/index/+title.ts
@@ -4,6 +4,6 @@ import type { Data } from './+data'
 import type { PageContext } from 'vike/types'
 
 function title(pageContext: PageContext<Data>) {
-  const movies = pageContext.data
+  const { movies } = pageContext.data
   return `${movies.length} Star Wars Movies`
 }

--- a/packages/vike-vue/src/hooks/useData.ts
+++ b/packages/vike-vue/src/hooks/useData.ts
@@ -8,7 +8,7 @@ import type { App, ShallowReactive } from 'vue'
 const key = 'vike-vue:useData'
 
 /** https://vike.dev/useData */
-function useData<Data>() {
+function useData<Data>(): ShallowReactive<Data> {
   const data = inject<ShallowReactive<Data>>(key)
   if (!data) throw new Error('setData() not called')
   return data

--- a/packages/vike-vue/src/hooks/useData.ts
+++ b/packages/vike-vue/src/hooks/useData.ts
@@ -3,17 +3,17 @@ export { useData }
 export { setData }
 
 import { inject } from 'vue'
-import type { App } from 'vue'
+import type { App, ShallowReactive } from 'vue'
 
 const key = 'vike-vue:useData'
 
 /** https://vike.dev/useData */
-function useData<Data>(): Data {
-  const data = inject(key)
+function useData<Data>() {
+  const data = inject<ShallowReactive<Data>>(key)
   if (!data) throw new Error('setData() not called')
-  return data as any
+  return data
 }
 
-function setData(app: App, data: unknown): void {
+function setData(app: App, data: ShallowReactive<unknown>): void {
   app.provide(key, data)
 }

--- a/packages/vike-vue/src/hooks/usePageContext.ts
+++ b/packages/vike-vue/src/hooks/usePageContext.ts
@@ -8,6 +8,7 @@ import type { PageContext } from 'vike/types'
 
 const key = 'vike-vue:usePageContext'
 
+/** https://vike.dev/usePageContext */
 function usePageContext(): ShallowReactive<PageContext> {
   const pageContext = inject<ShallowReactive<PageContext>>(key)
   if (!pageContext) throw new Error('setPageContext() not called')

--- a/packages/vike-vue/src/hooks/usePageContext.ts
+++ b/packages/vike-vue/src/hooks/usePageContext.ts
@@ -3,16 +3,16 @@ export { usePageContext }
 export { setPageContext }
 
 import { inject } from 'vue'
-import type { App } from 'vue'
+import type { App, ShallowReactive } from 'vue'
 import type { PageContext } from 'vike/types'
 
 const key = 'vike-vue:usePageContext'
 
 function usePageContext() {
-  const pageContext = inject(key)
-  return pageContext as PageContext
+  const pageContext = inject<ShallowReactive<PageContext>>(key)
+  return pageContext!
 }
 
-function setPageContext(app: App, pageContext: PageContext) {
+function setPageContext(app: App, pageContext: ShallowReactive<PageContext>) {
   app.provide(key, pageContext)
 }

--- a/packages/vike-vue/src/hooks/usePageContext.ts
+++ b/packages/vike-vue/src/hooks/usePageContext.ts
@@ -10,7 +10,8 @@ const key = 'vike-vue:usePageContext'
 
 function usePageContext() {
   const pageContext = inject<ShallowReactive<PageContext>>(key)
-  return pageContext!
+  if (!pageContext) throw new Error('setPageContext() not called')
+  return pageContext
 }
 
 function setPageContext(app: App, pageContext: ShallowReactive<PageContext>) {

--- a/packages/vike-vue/src/hooks/usePageContext.ts
+++ b/packages/vike-vue/src/hooks/usePageContext.ts
@@ -8,7 +8,7 @@ import type { PageContext } from 'vike/types'
 
 const key = 'vike-vue:usePageContext'
 
-function usePageContext() {
+function usePageContext(): ShallowReactive<PageContext> {
   const pageContext = inject<ShallowReactive<PageContext>>(key)
   if (!pageContext) throw new Error('setPageContext() not called')
   return pageContext

--- a/packages/vike-vue/src/renderer/createVueApp.ts
+++ b/packages/vike-vue/src/renderer/createVueApp.ts
@@ -6,7 +6,7 @@ import type { PageContext } from 'vike/types'
 import { setPageContext } from '../hooks/usePageContext'
 import { objectAssign } from '../utils/objectAssign'
 import { callCumulativeHooks } from '../utils/callCumulativeHooks'
-import { isObject } from '../utils/isObject'
+import { isPlainObject } from '../utils/isPlainObject'
 import { setData } from '../hooks/useData'
 
 type ChangePage = (pageContext: PageContext) => Promise<void>
@@ -73,8 +73,7 @@ async function createVueApp(pageContext: PageContext, ssr: boolean, rootComponen
 }
 
 function assertDataIsObject(data: unknown): asserts data is Record<string, unknown> {
-  if (!isObject(data) || Array.isArray(data))
-    throw new Error('Return value of data() should be an object, undefined, or null')
+  if (!isPlainObject(data)) throw new Error('Return value of data() should be a plain object, undefined, or null')
 }
 
 export function objectReplace(obj: object, objAddendum: object) {

--- a/packages/vike-vue/src/renderer/createVueApp.ts
+++ b/packages/vike-vue/src/renderer/createVueApp.ts
@@ -4,7 +4,7 @@ export type { ChangePage }
 import { type App, createApp, createSSRApp, h, markRaw, nextTick, ref, shallowReactive } from 'vue'
 import type { PageContext } from 'vike/types'
 import { setPageContext } from '../hooks/usePageContext'
-import { objectAssign, objectCleanAssign } from '../utils/objectAssign'
+import { objectAssign } from '../utils/objectAssign'
 import { callCumulativeHooks } from '../utils/callCumulativeHooks'
 import { isObject } from '../utils/isObject'
 import { setData } from '../hooks/useData'
@@ -75,4 +75,16 @@ async function createVueApp(pageContext: PageContext, ssr: boolean, rootComponen
 function assertDataIsObject(data: unknown): asserts data is Record<string, unknown> {
   if (!isObject(data) || Array.isArray(data))
     throw new Error('Return value of data() should be an object, undefined, or null')
+}
+
+export function objectCleanAssign<Obj extends object, ObjAddendum>(obj: Obj, objAddendum: ObjAddendum) {
+  const objCleanup: any = {}
+  const keys = Object.keys(obj)
+  const cleanAllKeys = !isObject(objAddendum)
+  for (let i = keys.length; --i >= 0; ) {
+    if (cleanAllKeys || !objAddendum.hasOwnProperty(keys[i] as string)) {
+      objCleanup[keys[i] as string] = undefined
+    }
+  }
+  Object.assign(obj, objCleanup, objAddendum)
 }

--- a/packages/vike-vue/src/renderer/createVueApp.ts
+++ b/packages/vike-vue/src/renderer/createVueApp.ts
@@ -41,8 +41,8 @@ async function createVueApp(pageContext: PageContext, ssr: boolean, rootComponen
     }
     const data = pageContext.data ?? {}
     assertDataIsObject(data)
-    objectCleanAssign(dataReactive, data)
-    objectCleanAssign(pageContextReactive, pageContext)
+    objectReplace(dataReactive, data)
+    objectReplace(pageContextReactive, pageContext)
     rootComponentRef.value = markRaw(pageContext.config[rootComponentName])
     layoutRef.value = markRaw(pageContext.config.Layout)
     await nextTick()
@@ -77,14 +77,8 @@ function assertDataIsObject(data: unknown): asserts data is Record<string, unkno
     throw new Error('Return value of data() should be an object, undefined, or null')
 }
 
-export function objectCleanAssign<Obj extends object, ObjAddendum>(obj: Obj, objAddendum: ObjAddendum) {
-  const objCleanup: any = {}
-  const keys = Object.keys(obj)
-  const cleanAllKeys = !isObject(objAddendum)
-  for (let i = keys.length; --i >= 0; ) {
-    if (cleanAllKeys || !objAddendum.hasOwnProperty(keys[i] as string)) {
-      objCleanup[keys[i] as string] = undefined
-    }
-  }
-  Object.assign(obj, objCleanup, objAddendum)
+export function objectReplace(obj: object, objAddendum: object) {
+  // @ts-ignore
+  Object.keys(obj).forEach((key) => delete obj[key])
+  Object.assign(obj, objAddendum)
 }

--- a/packages/vike-vue/src/utils/isObject.ts
+++ b/packages/vike-vue/src/utils/isObject.ts
@@ -1,3 +1,0 @@
-export function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null
-}

--- a/packages/vike-vue/src/utils/isPlainObject.ts
+++ b/packages/vike-vue/src/utils/isPlainObject.ts
@@ -1,0 +1,19 @@
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  // Is object?
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  // Support `Object.create(null)`
+  if (Object.getPrototypeOf(value) === null) {
+    return true
+  }
+
+  // Is plain object?
+  return (
+    /* Doesn't work in Cloudflare Pages workers
+    value.constructor === Object
+    */
+    value.constructor.name === 'Object'
+  )
+}

--- a/packages/vike-vue/src/utils/objectAssign.ts
+++ b/packages/vike-vue/src/utils/objectAssign.ts
@@ -1,7 +1,24 @@
+import { isObject } from './isObject'
+
 // Same as `Object.assign()` but with type inference
 export function objectAssign<Obj extends object, ObjAddendum>(
   obj: Obj,
   objAddendum: ObjAddendum,
 ): asserts obj is Obj & ObjAddendum {
   Object.assign(obj, objAddendum)
+}
+
+export function objectCleanAssign<Obj extends object, ObjAddendum>(
+  obj: Obj,
+  objAddendum: ObjAddendum,
+): asserts obj is Obj & ObjAddendum {
+  const objCleanup: any = {}
+  const keys = Object.keys(obj)
+  const cleanAllKeys = !isObject(objAddendum)
+  for (let i = keys.length; --i >= 0; ) {
+    if (cleanAllKeys || !objAddendum.hasOwnProperty(keys[i] as string)) {
+      objCleanup[keys[i] as string] = undefined
+    }
+  }
+  Object.assign(obj, objCleanup, objAddendum)
 }

--- a/packages/vike-vue/src/utils/objectAssign.ts
+++ b/packages/vike-vue/src/utils/objectAssign.ts
@@ -1,24 +1,7 @@
-import { isObject } from './isObject'
-
 // Same as `Object.assign()` but with type inference
 export function objectAssign<Obj extends object, ObjAddendum>(
   obj: Obj,
   objAddendum: ObjAddendum,
 ): asserts obj is Obj & ObjAddendum {
   Object.assign(obj, objAddendum)
-}
-
-export function objectCleanAssign<Obj extends object, ObjAddendum>(
-  obj: Obj,
-  objAddendum: ObjAddendum,
-): asserts obj is Obj & ObjAddendum {
-  const objCleanup: any = {}
-  const keys = Object.keys(obj)
-  const cleanAllKeys = !isObject(objAddendum)
-  for (let i = keys.length; --i >= 0; ) {
-    if (cleanAllKeys || !objAddendum.hasOwnProperty(keys[i] as string)) {
-      objCleanup[keys[i] as string] = undefined
-    }
-  }
-  Object.assign(obj, objCleanup, objAddendum)
 }


### PR DESCRIPTION
BREAKING CHANGE: data from `+data` hook must be a non-array object (if you need to return a list wrap it in an object)
BREAKING CHANGE: both `useData` and `usePageContext` return `shallowReactive` instead of `reactive`

closes #116, closes #121
