### PR TITLE
fix & improve clientOnly() squashed commit

### DIFF
--- a/examples/full/readme.md
+++ b/examples/full/readme.md
@@ -3,7 +3,7 @@ Full-fledged example of using `vike-vue`, showcasing:
 - [Layout](https://vike.dev/Layout)
 - Fetching data with [`data()`](https://vike.dev/data)
 - [Nested Layout](https://vike.dev/Layout#nested-layouts)
-- [`clientOnly()`](https://vike.dev/ClientOnly)
+- [`clientOnly()`](https://vike.dev/clientOnly)
 - [Toggling SSR](https://vike.dev/ssr) on a per-page basis.
 - [Markdown](https://vike.dev/markdown)
 - [Route Function](https://vike.dev/route-function)

--- a/examples/full/readme.md
+++ b/examples/full/readme.md
@@ -3,7 +3,7 @@ Full-fledged example of using `vike-vue`, showcasing:
 - [Layout](https://vike.dev/Layout)
 - Fetching data with [`data()`](https://vike.dev/data)
 - [Nested Layout](https://vike.dev/Layout#nested-layouts)
-- [`clientOnly`](https://vike.dev/ClientOnly)
+- [`clientOnly()`](https://vike.dev/ClientOnly)
 - [Toggling SSR](https://vike.dev/ssr) on a per-page basis.
 - [Markdown](https://vike.dev/markdown)
 - [Route Function](https://vike.dev/route-function)

--- a/packages/vike-vue/README.md
+++ b/packages/vike-vue/README.md
@@ -101,7 +101,7 @@ All hooks are [cumulative](https://vike.dev/meta#api), so you can add your own h
 
 `vike-vue` introduces the following new utility functions:
 
-* [`clientOnly`](https://vike.dev/ClientOnly): Creates a wrapper component to load and render a component only on the client-side.
+* [`clientOnly`](https://vike.dev/ClientOnly): load and render a component only on the client-side.
 
 ## Teleports
 

--- a/packages/vike-vue/README.md
+++ b/packages/vike-vue/README.md
@@ -101,7 +101,7 @@ All hooks are [cumulative](https://vike.dev/meta#api), so you can add your own h
 
 `vike-vue` introduces the following new helpers:
 
-* [`clientOnly()`](https://vike.dev/ClientOnly): load and render a component only on the client-side.
+* [`clientOnly()`](https://vike.dev/clientOnly): load and render a component only on the client-side.
 
 ## Teleports
 

--- a/packages/vike-vue/README.md
+++ b/packages/vike-vue/README.md
@@ -97,11 +97,11 @@ All hooks are [cumulative](https://vike.dev/meta#api), so you can add your own h
 * [`usePageContext()`](https://vike.dev/usePageContext): Access the [`pageContext` object](https://vike.dev/pageContext)
   from any component.
 
-## Utilities
+## Helpers
 
-`vike-vue` introduces the following new utility functions:
+`vike-vue` introduces the following new helpers:
 
-* [`clientOnly`](https://vike.dev/ClientOnly): load and render a component only on the client-side.
+* [`clientOnly()`](https://vike.dev/ClientOnly): load and render a component only on the client-side.
 
 ## Teleports
 

--- a/packages/vike-vue/package.json
+++ b/packages/vike-vue/package.json
@@ -12,6 +12,10 @@
     "./usePageContext": "./dist/hooks/usePageContext.js",
     "./useData": "./dist/hooks/useData.js",
     "./clientOnly": "./dist/helpers/clientOnly.js",
+    "./ClientOnly": {
+      "default": "./dist/components/ClientOnly.js",
+      "types": "./dist/components/ClientOnly.vue.d.ts"
+    },
     "./types": {
       "default": "./dist/types/index.js",
       "types": "./dist/types/index.d.ts"
@@ -65,6 +69,9 @@
       ],
       "renderer/onRenderClient": [
         "./dist/renderer/onRenderClient.d.ts"
+      ],
+      "ClientOnly": [
+        "./dist/components/ClientOnly.vue.d.ts"
       ]
     }
   },

--- a/packages/vike-vue/src/components/ClientOnly.vue
+++ b/packages/vike-vue/src/components/ClientOnly.vue
@@ -6,6 +6,9 @@
 import { h, ref, onMounted, defineAsyncComponent, useSlots, type AsyncComponentLoader } from 'vue'
 import type { Component } from '../types/PageContext'
 
+// TODO/eventually: remove <ClientOnly> component
+console.warn('[vike-vue][warning] <ClientOnly> is deprecated, use clientOnly() instead')
+
 type Props = {
   load: T
 }

--- a/packages/vike-vue/src/components/ClientOnly.vue
+++ b/packages/vike-vue/src/components/ClientOnly.vue
@@ -1,0 +1,36 @@
+<template>
+  <ClientComponent v-if="client" />
+</template>
+
+<script lang="ts" setup generic="T extends AsyncComponentLoader">
+import { h, ref, onMounted, defineAsyncComponent, useSlots, type AsyncComponentLoader } from 'vue'
+import type { Component } from '../types/PageContext'
+
+type Props = {
+  load: T
+}
+
+const props = defineProps<Props>()
+
+type Slots = {
+  fallback?: () => Component
+}
+
+defineSlots<Slots>()
+const slots = useSlots()
+
+const ClientComponent = defineAsyncComponent({
+  loader: props.load,
+  loadingComponent: slots.fallback,
+  onError: (e) => {
+    console.error('Component loading failed:', e)
+    throw e
+  },
+  suspensible: false,
+})
+
+const client = ref(false)
+onMounted(() => {
+  client.value = true
+})
+</script>

--- a/packages/vike-vue/src/helpers/clientOnly.ts
+++ b/packages/vike-vue/src/helpers/clientOnly.ts
@@ -3,6 +3,11 @@ export { clientOnly }
 import { h, nextTick, shallowRef, defineComponent, onBeforeMount } from 'vue'
 import type { Component, SlotsType } from 'vue'
 
+/**
+ * Load and render a component only on the client-side.
+ *
+ * https://vike.dev/ClientOnly
+ */
 function clientOnly<ComponentLoaded extends Component>(
   load: () => Promise<ComponentLoaded | { default: ComponentLoaded }>,
 ) {

--- a/packages/vike-vue/src/helpers/clientOnly.ts
+++ b/packages/vike-vue/src/helpers/clientOnly.ts
@@ -6,7 +6,7 @@ import type { Component, SlotsType } from 'vue'
 /**
  * Load and render a component only on the client-side.
  *
- * https://vike.dev/ClientOnly
+ * https://vike.dev/clientOnly
  */
 function clientOnly<ComponentLoaded extends Component>(
   load: () => Promise<ComponentLoaded | { default: ComponentLoaded }>,

--- a/packages/vike-vue/vite.config.js
+++ b/packages/vike-vue/vite.config.js
@@ -18,6 +18,7 @@ export default defineConfig({
         ['types/index']: resolve(__dirname, './src/types/index.ts'),
         ['hooks/usePageContext']: resolve(__dirname, './src/hooks/usePageContext.ts'),
         ['hooks/useData']: resolve(__dirname, './src/hooks/useData.ts'),
+        ['components/ClientOnly']: resolve(__dirname, './src/components/ClientOnly.vue'),
       },
       formats: ['es'],
     },


### PR DESCRIPTION
I'll squash these changes to the squashed commit, change the commit message, force push to `main`, and release a new version.

```
feat: `clientOnly()` helper (#110, fix #82)
```

I changed my mind: this PR restores `<ClientOnly>` and adds a deprecation warning. (We introduced quite a lot of breaking changes recently.)

@pdanpdan You mentioned that the `clientOnly()` usage example can be made easier? I'll go ahead and merge this PR but we can simplify the example in a follow-up PR.