### PR TITLE
Fix for useConfig hook client side 

### DIFF
--- a/packages/vike-vue/src/hooks/useConfig/useConfig-client.ts
+++ b/packages/vike-vue/src/hooks/useConfig/useConfig-client.ts
@@ -22,7 +22,8 @@ function useConfig(): (config: ConfigFromHook) => void {
     if (!('_headAlreadySet' in pageContext)) {
       setPageContextConfigFromHook(config, pageContext)
     } else {
-      apply(config)
+      // We need to use setTimeout() for this to work, even if the delay is 0ms.
+      setTimeout(() => apply(config), 0)
     }
   }
 }

--- a/packages/vike-vue/src/renderer/createVueApp.ts
+++ b/packages/vike-vue/src/renderer/createVueApp.ts
@@ -20,7 +20,7 @@ import { isPlainObject } from '../utils/isPlainObject'
 import { setData } from '../hooks/useData'
 import type { PageContextInternal } from '../types/PageContext'
 
-type ChangePage = (pageContext: PageContext) => Promise<void>
+type ChangePage = (pageContext: PageContext & PageContextInternal) => Promise<void>
 async function createVueApp(
   pageContext: PageContext & PageContextInternal,
   ssr: boolean,
@@ -70,7 +70,8 @@ async function createVueApp(
   setData(app, dataReactive)
 
   // changePage() is called upon navigation, see +onRenderClient.ts
-  const changePage: ChangePage = async (pageContext: PageContext) => {
+  const changePage: ChangePage = async (pageContext) => {
+    pageContext._headAlreadySet = true
     let returned = false
     let err: unknown
     app.config.errorHandler = (err_) => {

--- a/packages/vike-vue/src/renderer/onRenderClient.ts
+++ b/packages/vike-vue/src/renderer/onRenderClient.ts
@@ -44,8 +44,6 @@ const onRenderClient: OnRenderClientAsync = async (pageContext): ReturnType<OnRe
 }
 
 function updateDocument(pageContext: PageContextClient & PageContextInternal) {
-  pageContext._headAlreadySet = true
-
   const title = getHeadSetting<string | null>('title', pageContext)
   const lang = getHeadSetting<string | null>('lang', pageContext)
 


### PR DESCRIPTION
Hi @brillout,

I've finally been able to fix the problems I encountered while working on the `<Head>` and `<Config>` components..

So the problems are:
1. `pageContext._headAlreadySet` is always `undefined` when navigating between pages.
2. Even if problem 1 is solved and `apply(config)` is eventually called, the page title still doesn't change (by navigating between pages) when we use it like this:

```+Page.vue
<script lang="ts" setup>
import { useConfig } from 'vike-vue/useConfig'

const config = useConfig()
config({ title: 'title changed' })
</script>
```

I'm not sure why, but problem 2 can be resolved by using `setTimeout()`, even if the delay is set to 0ms.