### PR TITLE
fix: preserve client-side useConfig() settings in server-side pageContext (fix #233)

### DIFF
--- a/examples/full/.testRun.ts
+++ b/examples/full/.testRun.ts
@@ -178,6 +178,22 @@ function testUseConfig() {
     await page.goto(getServerUrl() + '/')
     expect(await page.title()).toBe('My Vike + Vue App')
   })
+  // The <title> set via useConfig() inside a server-side +data() hook should be applied upon
+  // client-side navigation (and persist in prerendered `*.pageContext.json` files).
+  // https://github.com/vikejs/vike-vue/issues/233
+  test('useConfig() in +data() upon client-side navigation', async () => {
+    await page.goto(getServerUrl() + '/')
+    expect(await page.title()).toBe('My Vike + Vue App')
+    await testCounter()
+    await page.click('a:has-text("Data Fetching")')
+    await ensureWasClientSideRouted('/pages/index')
+    // The movie page sets its <title> via useConfig({ title }) inside its server-side +data() hook.
+    await page.click('a:has-text("Return of the Jedi")')
+    await autoRetry(async () => {
+      expect(await page.title()).toBe('Return of the Jedi')
+    })
+    await ensureWasClientSideRouted('/pages/index')
+  })
 }
 
 function testConfigComponent() {

--- a/packages/vike-vue/src/hooks/useConfig/configsClientSide.ts
+++ b/packages/vike-vue/src/hooks/useConfig/configsClientSide.ts
@@ -1,4 +1,3 @@
-// The `useConfig()` settings that the client-side applies upon (client-side) navigation, see applyHeadSettings().
-// All other settings are HTML-only and/or non-serializable (e.g. <Head> components), thus we don't pass them to the client-side.
+// Settings the client-side applies upon navigation, see applyHeadSettings(). The others are HTML-only.
 export const configsClientSide = ['title', 'lang'] as const
 export type ConfigsClientSide = (typeof configsClientSide)[number]

--- a/packages/vike-vue/src/hooks/useConfig/configsClientSide.ts
+++ b/packages/vike-vue/src/hooks/useConfig/configsClientSide.ts
@@ -1,3 +1,2 @@
 // Settings the client-side applies upon navigation, see applyHeadSettings(). The others are HTML-only.
 export const configsClientSide = ['title', 'lang'] as const
-export type ConfigsClientSide = (typeof configsClientSide)[number]

--- a/packages/vike-vue/src/hooks/useConfig/configsClientSide.ts
+++ b/packages/vike-vue/src/hooks/useConfig/configsClientSide.ts
@@ -1,0 +1,4 @@
+// The `useConfig()` settings that the client-side applies upon (client-side) navigation, see applyHeadSettings().
+// All other settings are HTML-only and/or non-serializable (e.g. <Head> components), thus we don't pass them to the client-side.
+export const configsClientSide = ['title', 'lang'] as const
+export type ConfigsClientSide = (typeof configsClientSide)[number]

--- a/packages/vike-vue/src/hooks/useConfig/useConfig-server.ts
+++ b/packages/vike-vue/src/hooks/useConfig/useConfig-server.ts
@@ -8,6 +8,7 @@ import { getPageContext } from 'vike/getPageContext'
 import { objectKeys } from '../../utils/objectKeys.js'
 import { includes } from '../../utils/includes.js'
 import { configsCumulative } from './configsCumulative.js'
+import { configsClientSide } from './configsClientSide.js'
 import { type MaybeRefOrGetter, toValue } from 'vue'
 
 /**
@@ -31,12 +32,11 @@ function useConfig(): (config: MaybeRefOrGetter<ConfigViaHook>) => void {
   }
 }
 
-const configsClientSide = ['title']
 function setPageContextConfigViaHook(config: ConfigViaHook, pageContext: PageContext & PageContextInternal) {
   pageContext._configViaHook ??= {}
   objectKeys(config).forEach((configName) => {
     // Skip HTML only configs which the client-side doesn't need, saving KBs sent to the client as well as avoiding serialization errors.
-    if (pageContext.isClientSideNavigation && !configsClientSide.includes(configName)) return
+    if (pageContext.isClientSideNavigation && !includes(configsClientSide, configName)) return
 
     if (!includes(configsCumulative, configName)) {
       // Overridable config

--- a/packages/vike-vue/src/integration/onRenderHtml.ts
+++ b/packages/vike-vue/src/integration/onRenderHtml.ts
@@ -11,8 +11,9 @@ import { createVueApp } from './createVueApp.js'
 import { getHeadSetting } from './getHeadSetting.js'
 import { getTagAttributesString, type TagAttributes } from '../utils/getTagAttributesString.js'
 import type { PageContextInternal } from '../types/PageContext.js'
-import type { ConfigViaHookResolved } from '../types/Config.js'
 import { configsClientSide } from '../hooks/useConfig/configsClientSide.js'
+import { objectKeys } from '../utils/objectKeys.js'
+import { includes } from '../utils/includes.js'
 import { isNotNullish } from '../utils/isNotNullish.js'
 import { isObject } from '../utils/isObject.js'
 import { isType } from '../utils/isType.js'
@@ -30,22 +31,9 @@ const onRenderHtml: OnRenderHtmlAsync = async (
 
   const { htmlAttributesString, bodyAttributesString } = getTagAttributes(pageContext)
 
-  // `_configViaHook` may contain HTML-only and/or non-serializable values (such as <Head> components).
-  // We keep only the settings that the client-side applies upon navigation (see applyHeadSettings()), and
-  // remove everything else.
-  // - Saves KBs sent to the client.
-  // - Avoids serialization errors.
-  // - The kept values (e.g. `title`) are preserved in prerendered `*.pageContext.json` files, so that
-  //   they're available upon client-side navigation of statically deployed (pre-rendered) apps.
-  //   https://github.com/vikejs/vike-vue/issues/233
-  if (pageContext._configViaHook) {
-    const configViaHook: ConfigViaHookResolved = {}
-    for (const configName of configsClientSide) {
-      const configValue = pageContext._configViaHook[configName]
-      if (configValue !== undefined) configViaHook[configName] = configValue as any
-    }
-    pageContext._configViaHook = configViaHook
-  }
+  // Keep only what the client-side applies upon navigation, and remove the rest (HTML-only and/or
+  // non-serializable values such as <Head> components). https://github.com/vikejs/vike-vue/issues/233
+  removeServerOnlyConfigViaHook(pageContext)
 
   // pageContext.{pageHtmlString,pageHtmlStream} is set by renderPageToHtml() and can be overridden by user at onAfterRenderHtml()
   let pageHtmlStringOrStream: string | ReturnType<typeof dangerouslySkipEscape> | PageHtmlStream =
@@ -82,6 +70,16 @@ const onRenderHtml: OnRenderHtmlAsync = async (
       fromHtmlRenderer,
     },
   }
+}
+
+function removeServerOnlyConfigViaHook(pageContext: PageContextInternal) {
+  const configViaHook = pageContext._configViaHook
+  if (!configViaHook) return
+  objectKeys(configViaHook).forEach((configName) => {
+    if (!includes(configsClientSide, configName)) delete configViaHook[configName]
+  })
+  // Remove it altogether if there isn't anything left, saving KBs sent to the client
+  if (objectKeys(configViaHook).length === 0) delete pageContext._configViaHook
 }
 
 export type PageHtmlStream = ReturnType<typeof renderToNodeStream> | ReturnType<typeof renderToWebStream>

--- a/packages/vike-vue/src/integration/onRenderHtml.ts
+++ b/packages/vike-vue/src/integration/onRenderHtml.ts
@@ -11,6 +11,8 @@ import { createVueApp } from './createVueApp.js'
 import { getHeadSetting } from './getHeadSetting.js'
 import { getTagAttributesString, type TagAttributes } from '../utils/getTagAttributesString.js'
 import type { PageContextInternal } from '../types/PageContext.js'
+import type { ConfigViaHookResolved } from '../types/Config.js'
+import { configsClientSide } from '../hooks/useConfig/configsClientSide.js'
 import { isNotNullish } from '../utils/isNotNullish.js'
 import { isObject } from '../utils/isObject.js'
 import { isType } from '../utils/isType.js'
@@ -28,8 +30,22 @@ const onRenderHtml: OnRenderHtmlAsync = async (
 
   const { htmlAttributesString, bodyAttributesString } = getTagAttributes(pageContext)
 
-  // Not needed on the client-side, thus we remove it to save KBs sent to the client
-  delete pageContext._configViaHook
+  // `_configViaHook` may contain HTML-only and/or non-serializable values (such as <Head> components).
+  // We keep only the settings that the client-side applies upon navigation (see applyHeadSettings()), and
+  // remove everything else.
+  // - Saves KBs sent to the client.
+  // - Avoids serialization errors.
+  // - The kept values (e.g. `title`) are preserved in prerendered `*.pageContext.json` files, so that
+  //   they're available upon client-side navigation of statically deployed (pre-rendered) apps.
+  //   https://github.com/vikejs/vike-vue/issues/233
+  if (pageContext._configViaHook) {
+    const configViaHook: ConfigViaHookResolved = {}
+    for (const configName of configsClientSide) {
+      const configValue = pageContext._configViaHook[configName]
+      if (configValue !== undefined) configViaHook[configName] = configValue as any
+    }
+    pageContext._configViaHook = configViaHook
+  }
 
   // pageContext.{pageHtmlString,pageHtmlStream} is set by renderPageToHtml() and can be overridden by user at onAfterRenderHtml()
   let pageHtmlStringOrStream: string | ReturnType<typeof dangerouslySkipEscape> | PageHtmlStream =


### PR DESCRIPTION
Fixes #233

## Problem

When a prerendered Vike + Vue app sets `title` via `useConfig({ title })` inside a server `+data()` hook, the initial HTML has the correct `<title>`, but `document.title` is **not** updated upon client-side navigation on statically deployed apps. A page refresh fixes it.

### Root cause

Settings passed via `useConfig()` are stored in `pageContext._configViaHook`, which is part of `passToClient`. However, `onRenderHtml()` deleted the **entire** `_configViaHook` object before the prerendered `*.pageContext.json` was serialized:

```ts
// Not needed on the client-side, thus we remove it to save KBs sent to the client
delete pageContext._configViaHook
```

For non-prerendered apps this is harmless: client-side navigation re-runs `+data()` on the server (with `isClientSideNavigation`), which re-populates `_configViaHook` in a fresh `pageContext.json` that never goes through `onRenderHtml()`. But for **prerendered** apps the `*.pageContext.json` files *are* produced from the render that `onRenderHtml()` mutated — so the `title` was stripped and lost on client navigation.

## Fix

Instead of deleting `_configViaHook` wholesale, keep only the settings the client-side actually applies upon navigation — `title` and `lang` (see `applyHeadSettings()`) — and drop everything else (HTML-only and/or non-serializable values such as `<Head>` components):

```ts
if (pageContext._configViaHook) {
  const configViaHook: ConfigViaHookResolved = {}
  for (const configName of configsClientSide) {
    const configValue = pageContext._configViaHook[configName]
    if (configValue !== undefined) configViaHook[configName] = configValue as any
  }
  pageContext._configViaHook = configViaHook
}
```

This still saves KBs and avoids serialization errors (non-serializable values are removed), while preserving the values needed for client-side navigation of prerendered apps.

The client-side settings list is now a single shared `configsClientSide` constant, reused by both `onRenderHtml()` and `useConfig()` (server). Previously the server hook hard-coded `['title']`; it now also includes `lang`, which `applyHeadSettings()` applies on the client too.

### On the client, `_configViaHook` is only read for `title`/`lang`

- `getHeadSetting()` (used by `onRenderClient` → `applyHead`) reads only `title` and `lang`.
- The `Head` entry is read in `createVueApp()` **only** for the server-side `'Head'` app; the client only ever builds the `'Page'` app.

So narrowing the client payload to `title`/`lang` is safe.

## Testing

- `vue-tsc --noEmit` and the package build pass.
- Added an e2e test to the `full` example (`useConfig() in +data() upon client-side navigation`) that navigates client-side to a page whose `<title>` is set via `useConfig({ title })` in its server `+data()` hook, and asserts `document.title` updates. The dev e2e suite passes.

> Note: the existing test infra has no prerendered example, so the added e2e exercises the runtime client-navigation path (a regression guard for the shared `configsClientSide` filtering). The prerender-specific behavior is addressed by no longer discarding the serializable settings from the serialized `pageContext`.

## Note on other packages

`vike-react` has the same `delete pageContext._configViaHook` pattern in its `onRenderHtml`, so it likely has the same bug. I scoped this PR to `vike-vue` (the reported issue) — happy to port the fix to `vike-react` if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SvFjBdBmQ2wVMBHwHmouky)_