### PR TITLE
feat: new setting `+vue` (`vue.keepAlive`, fix vikejs/vike#3433)

### DIFF
--- a/examples/full/.testRun.ts
+++ b/examples/full/.testRun.ts
@@ -40,6 +40,8 @@ function testRun(cmd: `pnpm run ${'dev' | 'preview'}`) {
 
   testClientOnly()
 
+  testKeepAlive()
+
   const textNoSSR = 'This page is rendered only in the browser'
   {
     const url = '/without-ssr'
@@ -293,6 +295,29 @@ function getAssetUrl(fileName: string) {
 
 function countMatches(haystack: string, needleRe: RegExp) {
   return (haystack.match(new RegExp(needleRe, 'g')) || []).length
+}
+
+// https://vike.dev/vue-setting
+function testKeepAlive() {
+  test('keepAlive - page state is preserved across client-side navigation', async () => {
+    await page.goto(getServerUrl() + '/keep-alive/first')
+    expect(await page.textContent('h1')).toBe('KeepAlive - First Page')
+    await testCounter()
+
+    await page.click('a:has-text("KeepAlive - Second Page")')
+    await autoRetry(async () => {
+      expect(await page.textContent('h1')).toBe('KeepAlive - Second Page')
+    })
+    await ensureWasClientSideRouted('/pages/keep-alive/first')
+
+    await page.click('a:has-text("KeepAlive - First Page")')
+    await autoRetry(async () => {
+      expect(await page.textContent('h1')).toBe('KeepAlive - First Page')
+    })
+    await ensureWasClientSideRouted('/pages/keep-alive/first')
+    // The counter didn't reset to 0: the page's component instance was preserved by <KeepAlive>
+    expect(await page.textContent('button')).toContain('Counter 1')
+  })
 }
 
 function testClientOnly() {

--- a/examples/full/pages/keep-alive/+vue.ts
+++ b/examples/full/pages/keep-alive/+vue.ts
@@ -1,0 +1,6 @@
+import type { Config } from 'vike/types'
+
+// https://vike.dev/vue-setting
+export default {
+  keepAlive: true,
+} satisfies Config['vue']

--- a/examples/full/pages/keep-alive/first/+Page.vue
+++ b/examples/full/pages/keep-alive/first/+Page.vue
@@ -1,0 +1,10 @@
+<template>
+  <h1>KeepAlive - First Page</h1>
+  <p>This page's component instance is preserved across client-side navigation.</p>
+  <Counter />
+  <p><a href="/keep-alive/second">KeepAlive - Second Page</a></p>
+</template>
+
+<script lang="ts" setup>
+import Counter from '../../../components/Counter.vue'
+</script>

--- a/examples/full/pages/keep-alive/second/+Page.vue
+++ b/examples/full/pages/keep-alive/second/+Page.vue
@@ -1,0 +1,5 @@
+<template>
+  <h1>KeepAlive - Second Page</h1>
+  <p>Navigate back to the first page: its state is preserved.</p>
+  <p><a href="/keep-alive/first">KeepAlive - First Page</a></p>
+</template>

--- a/packages/vike-vue/src/+config.ts
+++ b/packages/vike-vue/src/+config.ts
@@ -38,6 +38,10 @@ const config = {
       env: { server: true, client: true },
       cumulative: true,
     },
+    vue: {
+      env: { server: true, client: true },
+      cumulative: true,
+    },
     title: {
       env: { server: true, client: true },
     },

--- a/packages/vike-vue/src/integration/createVueApp.ts
+++ b/packages/vike-vue/src/integration/createVueApp.ts
@@ -6,6 +6,7 @@ import {
   createApp,
   createSSRApp,
   h,
+  KeepAlive,
   nextTick,
   shallowRef,
   shallowReactive,
@@ -19,6 +20,7 @@ import { objectReplace } from '../utils/objectReplace.js'
 import { callCumulativeHooks } from '../utils/callCumulativeHooks.js'
 import { isPlainObject } from '../utils/isPlainObject.js'
 import { setData } from '../hooks/useData.js'
+import { resolveVueSetting } from './resolveVueSetting.js'
 import type { PageContextInternal } from '../types/PageContext.js'
 
 type ChangePage = (pageContext: PageContext) => Promise<void>
@@ -33,11 +35,21 @@ async function createVueApp(
   if (entryComponentName === 'Page') {
     const entryComponentRef = shallowRef(pageContext.config[entryComponentName])
     const layoutRef = shallowRef(pageContext.config.Layout || [])
+    const keepAliveRef = shallowRef(resolveVueSetting(pageContext).keepAlive ?? false)
     onChangePage = (pageContext: PageContext) => {
       entryComponentRef.value = pageContext.config[entryComponentName]
       layoutRef.value = pageContext.config.Layout || []
+      keepAliveRef.value = resolveVueSetting(pageContext).keepAlive ?? false
     }
-    const EntryComponent = () => h(entryComponentRef.value)
+    // Wrap <Page> with <KeepAlive>
+    // - It's the only way to make <KeepAlive> work: it cannot be applied inside a +Layout component
+    //   because <KeepAlive> only caches its direct child component, whereas <Layout> receives <Page>
+    //   as slot content (Vue renders slot content as a Fragment which <KeepAlive> cannot cache).
+    const EntryComponent = () => {
+      const keepAlive = keepAliveRef.value
+      if (!keepAlive) return h(entryComponentRef.value)
+      return h(KeepAlive, keepAlive === true ? null : keepAlive, () => h(entryComponentRef.value))
+    }
     RootComponent = () => {
       let RootComp = EntryComponent
       layoutRef.value.forEach((layout) => {

--- a/packages/vike-vue/src/integration/resolveVueSetting.ts
+++ b/packages/vike-vue/src/integration/resolveVueSetting.ts
@@ -1,0 +1,18 @@
+export { resolveVueSetting }
+
+import type { PageContext } from 'vike/types'
+
+type VueSettingResolved = Exclude<Vike.Config['vue'], Function | undefined>
+
+// The +vue setting is cumulative: we merge all values into a single object.
+function resolveVueSetting(pageContext: PageContext): VueSettingResolved {
+  const resolved: VueSettingResolved = {}
+  const values = pageContext.config.vue ?? []
+  // `values` is ordered by inheritance: the most specific value (e.g. defined at the page-level) comes first.
+  // We iterate in reverse so that more specific values override less specific ones (e.g. defined globally).
+  for (const value of [...values].reverse()) {
+    const val = typeof value === 'function' ? value(pageContext) : value
+    if (val) Object.assign(resolved, val)
+  }
+  return resolved
+}

--- a/packages/vike-vue/src/types/Config.ts
+++ b/packages/vike-vue/src/types/Config.ts
@@ -3,6 +3,21 @@ import type { TagAttributes } from '../utils/getTagAttributesString.js'
 import type { Viewport, HtmlInjection } from '../integration/onRenderHtml.js'
 import type { ConfigsCumulative } from '../hooks/useConfig/configsCumulative.js'
 import type { Component } from './PageContext.js'
+import type { KeepAliveProps } from 'vue'
+
+// https://vike.dev/vue-setting
+type VueSetting = {
+  /**
+   * Whether to wrap the `<Page>` component with Vue's built-in [`<KeepAlive>`](https://vuejs.org/guide/built-ins/keep-alive.html) component, preserving page component instances (and thus their state) across client-side navigation.
+   *
+   * Instead of `true`, you can provide `<KeepAlive>` props (e.g. `{ include, exclude, max }`) for controlling which page components are cached.
+   *
+   * @default false
+   *
+   * https://vike.dev/vue-setting#keepalive
+   */
+  keepAlive?: boolean | KeepAliveProps
+}
 
 // https://vike.dev/pageContext#typescript
 declare global {
@@ -23,6 +38,13 @@ declare global {
        * https://vike.dev/Layout
        */
       Layout?: Component
+
+      /**
+       * Vue integration settings.
+       *
+       * https://vike.dev/vue-setting
+       */
+      vue?: VueSetting | ((pageContext: PageContext_) => VueSetting | undefined)
 
       /**
        * Set the page's tilte.
@@ -242,6 +264,7 @@ declare global {
       bodyAttributes?: TagAttributes[]
       htmlAttributes?: TagAttributes[]
       stream?: Exclude<Config['stream'], ImportString>[]
+      vue?: Exclude<Config['vue'], undefined>[]
     }
   }
 }


### PR DESCRIPTION
## Description

New cumulative setting `+vue` for Vue integration options — the Vue counterpart of vike-react's [`+react`](https://vike.dev/react-setting) setting.

Its first option is `vue.keepAlive` (`boolean | KeepAliveProps`): it preserves page component instances — and thus their state — across client-side navigation, by wrapping the `<Page>` component with Vue's built-in [`<KeepAlive>`](https://vuejs.org/guide/built-ins/keep-alive.html) component.

Fixes the use case raised in https://github.com/orgs/vikejs/discussions/3433.

### Why the runtime (and not userland)?

Wrapping `<slot />` with `<KeepAlive>` inside a `+Layout` (or a hypothetical `+Wrapper`) component cannot work: `<KeepAlive>` only caches its direct child component, whereas slot content is rendered as a Fragment which `<KeepAlive>` cannot cache. So the only place `<KeepAlive>` can be applied is where `vike-vue` renders the routed `<Page>` component — i.e. in `createVueApp()`.

### Usage

```ts
// pages/+vue.ts
export default {
  keepAlive: true, // or <KeepAlive> props, e.g. { include, exclude, max }
} satisfies Config['vue']
```

The setting is cumulative and can also be a function of `pageContext` (like `+react`); more specific values override less specific ones.

### Changes

- `types/Config.ts`: new `vue` setting type (`VueSetting | ((pageContext) => VueSetting | undefined)`) with `keepAlive?: boolean | KeepAliveProps`.
- `+config.ts`: register the `vue` setting (`env: { server: true, client: true }`, `cumulative: true`).
- `integration/resolveVueSetting.ts`: merge the cumulative values (vike orders them most-specific first, so we merge in reverse for correct precedence) and call function values with `pageContext`.
- `createVueApp.ts`: conditionally wrap the routed `<Page>` component with `<KeepAlive>` (reactive across navigation, like `Layout`). `<KeepAlive>` is SSR-compatible — on the server it simply renders its child.
- `examples/full`: new `/keep-alive/first` + `/keep-alive/second` pages with a shared `+vue.ts` (`keepAlive: true`), and an e2e test asserting that a counter's state survives a round-trip client-side navigation.

### Testing

- `pnpm run build` ✅
- `pnpm exec test-e2e examples/full` ✅ (dev + preview, including the new keepAlive test)
- `pnpm run test:types` ✅
- `pnpm run format:check` ✅

Documentation PR: https://github.com/vikejs/vike/pull/3434 (docs for `https://vike.dev/vue-setting`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MU13ncNmLi5rz2xySmm5rZ